### PR TITLE
Fix non-NameExpr l-value expressions

### DIFF
--- a/doxxie/doxxie.py
+++ b/doxxie/doxxie.py
@@ -16,6 +16,7 @@ from mypy.nodes import AssignmentStmt
 from mypy.nodes import ClassDef
 from mypy.nodes import Decorator
 from mypy.nodes import FuncDef
+from mypy.nodes import NameExpr
 from mypy.nodes import SymbolTableNode
 from mypy.nodes import TypeInfo
 from mypy.nodes import Var
@@ -426,7 +427,11 @@ class MypyPlugin(Plugin):
                     self._api_hints.add(f"{modname}.{defn.name}")
                 elif isinstance(defn, AssignmentStmt):
                     for val in defn.lvalues:
-                        self._api_hints.add(f"{modname}.{val.name}")
+                        # TODO: Add support for TupleExpr and others listed below
+                        # https://github.com/python/mypy/blob/797544d8f97c478770eb178ba966cc7b1d0e6020/mypy/nodes.py#L203
+                        if isinstance(val, NameExpr):
+                            name = val.name
+                            self._api_hints.add(f"{modname}.{name}")
                 else:
                     pass
         log.debug("collected hints %r", self._api_hints)

--- a/tests/comprehensive/pkg/a.py
+++ b/tests/comprehensive/pkg/a.py
@@ -66,3 +66,6 @@ var = ExposedClass8()
 pub_var1 = pub_var2 = ExposedClass12()
 
 _var = _InternalClass()
+
+_x = [0]
+_x[0] = 4


### PR DESCRIPTION
Top level expressions that are not NameExpr such as IndexExpr don't
have a name attribute which resulted in an error.